### PR TITLE
MdePkg/BaseSynchronizationLib: fix AArch64 return values

### DIFF
--- a/MdePkg/Library/BaseSynchronizationLib/AArch64/Synchronization.S
+++ b/MdePkg/Library/BaseSynchronizationLib/AArch64/Synchronization.S
@@ -171,6 +171,7 @@ TryInternalSyncIncrement:
   add     w1, w1, #1
   stxr    w2, w1, [x0]
   cbnz    w2, TryInternalSyncIncrement
+  mov     w0, w1
   dmb     sy
   ret
 
@@ -199,5 +200,6 @@ TryInternalSyncDecrement:
   sub     w1, w1, #1
   stxr    w2, w1, [x0]
   cbnz    w2, TryInternalSyncDecrement
+  mov     w0, w1
   dmb     sy
   ret


### PR DESCRIPTION
Fix the wrong return value of both InternalSyncIncrement()
and InternalSyncDecrement(). The return value shouldn't
be the address of input parameter. It should be the updated
value of input parameter instead.

Contributed-under: TianoCore Contribution Agreement 1.0
Signed-off-by: Haojian Zhuang haojian.zhuang@linaro.org
Reviewed-by: Ard Biesheuvel ard.biesheuvel@linaro.org
Reviewed-by: Leif Lindholm leif.lindholm@linaro.org

git-svn-id: https://svn.code.sf.net/p/edk2/code/trunk/edk2@18685 6f19259b-4bc3-4df7-8a09-765794883524
